### PR TITLE
fix oxygen calculation to match Aanderaa SVU+phasecoef0

### DIFF
--- a/R/CTS5_USEA.R
+++ b/R/CTS5_USEA.R
@@ -755,6 +755,7 @@ cts5_ProcessData<-function(metadata,dataprofile,ProcessUncalibrated=F){
       
     if (is.list(metadata$SENSOR_DO)){
       coefs<-metadata$SENSOR_DO$SVU_FOIL_COEFF
+      phasecoef0<-metadata$SENSOR_DO$PHASE_COEFF
     }
       else {
       cat("!! Warning : No DO calibration found \n")
@@ -763,14 +764,19 @@ cts5_ProcessData<-function(metadata,dataprofile,ProcessUncalibrated=F){
       if (ProcessUncalibrated){
         cat("!! Default calibration is used \n")
         coefs <- c(5.6725661e-03,8.2915275e-05,1.0033795e-06,6.2236942e-02,-9.3470722e-05,-1.4554620e-02,1.2110645e-03) # From Henry
+        phasecoef0<-0
       }
       
       }
         
       if (!is.null(coefs)){
-      dataprofile$data$do[,"doxy_uncalibrated"]<-Process_DO_Bittig(C1phase=dataprofile$data$do[,"c1phase_deg"],C2phase=dataprofile$data$do[,"c2phase_deg"],temp=dataprofile$data$do[,"tempdoxy_degC"],Pres=dataprofile$data$do[,"Pressure_dbar"],
-                                             tempCTD=dataprofile$data$sbe41[,"Temperature_degC"],salCTD=dataprofile$data$sbe41[,"Salinity_PSU"],PRESCTD=dataprofile$data$sbe41[,"Pressure_dbar"],
-                                             COEF = coefs)
+      #dataprofile$data$do[,"doxy_uncalibrated"]<-Process_DO_Bittig(C1phase=dataprofile$data$do[,"c1phase_deg"],C2phase=dataprofile$data$do[,"c2phase_deg"],temp=dataprofile$data$do[,"tempdoxy_degC"],Pres=dataprofile$data$do[,"Pressure_dbar"],
+      #                                       tempCTD=dataprofile$data$sbe41[,"Temperature_degC"],salCTD=dataprofile$data$sbe41[,"Salinity_PSU"],PRESCTD=dataprofile$data$sbe41[,"Pressure_dbar"],
+      #                                       COEF = coefs)
+      
+      dataprofile$data$do[,"doxy_uncalibrated"]<-Process_DO_AADI_SVU(C1phase=dataprofile$data$do[,"c1phase_deg"],C2phase=dataprofile$data$do[,"c2phase_deg"],temp=dataprofile$data$do[,"tempdoxy_degC"],Pres=dataprofile$data$do[,"Pressure_dbar"],
+                                                                   tempCTD=dataprofile$data$sbe41[,"Temperature_degC"],salCTD=dataprofile$data$sbe41[,"Salinity_PSU"],PRESCTD=dataprofile$data$sbe41[,"Pressure_dbar"],
+                                                                   COEF = coefs, PHASECOEF0 = phasecoef0)
       }
     }
   }

--- a/R/Sensors_Processing.R
+++ b/R/Sensors_Processing.R
@@ -72,6 +72,73 @@ Process_DO_Bittig <- function(C1phase,C2phase,temp, Pres,tempCTD,salCTD, PRESCTD
   
 }
 
+#**************************************************
+#*
+# Compute do
+#*
+#**************************************************
+
+# Inputs : C1phase,C2phase,temp, Pres : data from the Optode. tempCTD,salCTD, PRESCTD : Data from the CTD
+
+Process_DO_AADI_SVU <- function(C1phase,C2phase,temp, Pres,tempCTD,salCTD, PRESCTD,COEF=NULL, PHASECOEF0=NULL) {
+  
+  tempCTD <- approx(PRESCTD, tempCTD, Pres, rule=2, ties = "mean")$y #Approx tempCTD on DO pressure
+  #tempCTD <- temp #We use the temperature from the Optode
+  
+  #Approx tempCTD on DO pressure
+  salCTD <- approx(PRESCTD,salCTD, Pres, rule=2,ties = "mean")$y 
+  
+  #COEF if NULL (for plotting)
+  if (is.null(COEF)){
+    COEF <- c(5.6725661e-03,8.2915275e-05,1.0033795e-06,6.2236942e-02,-9.3470722e-05,-1.4554620e-02,1.2110645e-03) # From Henry
+  }
+  if (is.null(PHASECOEF0)){
+    PHASECOEF0 <- 0 # From Henry
+  }
+  
+  TCPhase <-  (C1phase - C2phase) + PHASECOEF0
+  
+  # first part of pressure effect
+  TCPhase = TCPhase + 0.1 * Pres/1000 # do O2-independent phase adjustment
+  
+  KSV <-  COEF[1] + (COEF[2]  * temp) + (COEF[3] * temp * temp)
+  
+  #print(KSV[20:100])
+  
+  P0 <- COEF[4]  + COEF[5] * temp
+  
+  #print(P0[20:100])
+  
+  PC <- COEF[6]  + COEF[7] * TCPhase
+  
+  #print(PC[20:100])
+  # oxygen concentration in umol/l (in freshwater)
+  O2_molar_fresh <- ((P0/PC)-1) / KSV
+  
+  rhumid = 1
+  atm_press=1.01325
+  
+  pH2Ofresh = rhumid * (exp(24.4543-(67.4509*(100/(tempCTD+273.15)))-(4.8489*log(((273.15+tempCTD)/100)))-0.000544*0))
+  pH2O = rhumid * (exp(24.4543-(67.4509*(100/(tempCTD+273.15)))-(4.8489*log(((273.15+tempCTD)/100)))-0.000544*salCTD))
+  
+  #th0=1-(0.999025+0.00001426*tempCTD-0.00000006436*tempCTD^2)
+  sca_T=log((298.15-tempCTD)/(273.15+tempCTD))
+  Scorr=((exp(salCTD*(-0.00624097-0.00693498*sca_T-0.00690358*sca_T^2-0.00429155*sca_T^3)-0.00000031168*salCTD^2)))
+  # oxygen concentration in umol/l (salinity corrected)
+  O2_molar_salt=O2_molar_fresh*(atm_press-pH2Ofresh)/(atm_press-pH2O)*Scorr
+
+  # correcion de pression
+  #O2conc_sal = O2conc_sal * (1+ ((3.2)/100 *(Pres/1000)))
+  pcfactor=4.19+0.022*tempCTD
+  O2conc_sal = O2_molar_salt * (1+ ((pcfactor)/100 *(Pres/1000))) # in umol/L, pressure corrected, salinity compensated
+  
+  # divide by density to get umol/kg for DOXY
+  
+  return(O2conc_sal)
+  
+}
+
+
 
 
 #**************************************************


### PR DESCRIPTION
The current code does not match the calculation required for Aanderaa optodes. This commit adds a routine `Process_DO_AADI_SVU` that corresponds to the **Aanderaa 4330/4831 SVU multipoint calculation** with optional `PhaseCoef0` offset on `TCPhase`. 